### PR TITLE
Be less restrictive when adding items

### DIFF
--- a/common.go
+++ b/common.go
@@ -2,6 +2,14 @@ package hyperloglog
 
 import "math"
 
+type Hash32 interface {
+	Sum32() uint32
+}
+
+type Hash64 interface {
+	Sum64() uint64
+}
+
 type sortableSlice []uint32
 
 func (p sortableSlice) Len() int           { return len(p) }

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -13,7 +13,6 @@ package hyperloglog
 
 import (
 	"errors"
-	"hash"
 	"math"
 )
 
@@ -44,7 +43,7 @@ func (h *HyperLogLog) Clear() {
 }
 
 // Add adds a new item to HyperLogLog h.
-func (h *HyperLogLog) Add(item hash.Hash32) {
+func (h *HyperLogLog) Add(item Hash32) {
 	x := item.Sum32()
 	i := eb32(x, 32, 32-h.p) // {x31,...,x32-p}
 	w := x<<h.p | 1<<(h.p-1) // {x32-p,...,x0}

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -4,12 +4,7 @@ import "testing"
 
 type fakeHash32 uint32
 
-func (f fakeHash32) Write(p []byte) (n int, err error) { return 0, nil }
-func (f fakeHash32) Sum(b []byte) []byte               { return b }
-func (f fakeHash32) Reset()                            {}
-func (f fakeHash32) BlockSize() int                    { return 1 }
-func (f fakeHash32) Size() int                         { return 1 }
-func (f fakeHash32) Sum32() uint32                     { return uint32(f) }
+func (f fakeHash32) Sum32() uint32 { return uint32(f) }
 
 func TestHLLAdd(t *testing.T) {
 	h, _ := New(16)

--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -2,7 +2,6 @@ package hyperloglog
 
 import (
 	"errors"
-	"hash"
 	"sort"
 )
 
@@ -135,7 +134,7 @@ func (h *HyperLogLogPlus) toNormal() {
 }
 
 // Add adds a new item to HyperLogLogPlus h.
-func (h *HyperLogLogPlus) Add(item hash.Hash64) {
+func (h *HyperLogLogPlus) Add(item Hash64) {
 	x := item.Sum64()
 	if h.sparse {
 		h.tmpSet.Add(h.encodeHash(x))

--- a/hyperloglogplus_test.go
+++ b/hyperloglogplus_test.go
@@ -7,12 +7,7 @@ import (
 
 type fakeHash64 uint64
 
-func (f fakeHash64) Write(p []byte) (n int, err error) { return 0, nil }
-func (f fakeHash64) Sum(b []byte) []byte               { return b }
-func (f fakeHash64) Reset()                            {}
-func (f fakeHash64) BlockSize() int                    { return 1 }
-func (f fakeHash64) Size() int                         { return 1 }
-func (f fakeHash64) Sum64() uint64                     { return uint64(f) }
+func (f fakeHash64) Sum64() uint64 { return uint64(f) }
 
 func TestHLLPPAddNoSparse(t *testing.T) {
 	h, _ := NewPlus(16)


### PR DESCRIPTION
When adding items to sets, it's often impractical to use structs that implement full `hash.Hash32/hash.Hash64` method set. Most of my implementations contain a bunch of empty methods, pretty much what you have done in your tests with `fakeHash32/fakeHash64`.