### PR TITLE
Error message changed to reflect actual allowed precision range.

### DIFF
--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -94,7 +94,7 @@ func (h *HyperLogLogPlus) mergeSparse() {
 // algorithm.
 func NewPlus(precision uint8) (*HyperLogLogPlus, error) {
 	if precision > 18 || precision < 4 {
-		return nil, errors.New("precision must be between 4 and 16")
+		return nil, errors.New("precision must be between 4 and 18")
 	}
 
 	h := &HyperLogLogPlus{}


### PR DESCRIPTION
Upper bound in the error message was different than actual upper bound of the allowed precision (16 in error message, 18 in code) - probably copy/paste from HyperLogLog implementation.

Question: wouldn't it be possible to allow 18 as upper precision bound for HyperLogLog, to be the same as in HyperLogLog++? The difference is confusing ;)