### PR TITLE
HLL++ marshaling and unmarshaling

### DIFF
--- a/compressed.go
+++ b/compressed.go
@@ -72,17 +72,17 @@ func (v *variableLengthList) Iter() *iterator {
 func (v variableLengthList) decode(i int, last uint32) (uint32, int) {
 	var x uint32
 	j := i
-	for ; v[j] & 0x80 != 0; j++ {
-		x |= uint32(v[j] & 0x7f) << (uint(j - i) * 7)
+	for ; v[j]&0x80 != 0; j++ {
+		x |= uint32(v[j]&0x7f) << (uint(j-i) * 7)
 	}
-	x |= uint32(v[j]) << (uint(j - i) * 7)
+	x |= uint32(v[j]) << (uint(j-i) * 7)
 	return x, j + 1
 }
 
 func (v variableLengthList) Append(x uint32) variableLengthList {
-	for x & 0xffffff80 != 0 {
-		v = append(v, uint8((x & 0x7f) | 0x80))
+	for x&0xffffff80 != 0 {
+		v = append(v, uint8((x&0x7f)|0x80))
 		x >>= 7
 	}
-	return append(v, uint8(x & 0x7f))
+	return append(v, uint8(x&0x7f))
 }

--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -54,6 +54,10 @@ func (h *HyperLogLogPlus) decodeHash(k uint32) (uint32, uint8) {
 
 // Merge tmpSet and sparseList in the sparse representation.
 func (h *HyperLogLogPlus) mergeSparse() {
+	if len(h.tmpSet) == 0 {
+		return
+	}
+
 	keys := make(sortableSlice, 0, len(h.tmpSet))
 	for k := range h.tmpSet {
 		keys = append(keys, k)

--- a/marshalplus.go
+++ b/marshalplus.go
@@ -1,0 +1,241 @@
+package hyperloglog
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Marshal HyperLogLogPlus to and from []byte to make it easy to persist
+// to the datastore of your choice.
+
+// There is a version field so backwards compatibility can be maintained in the
+// future if the marshal format is changed.
+
+/*
+
+Here is a diagram of the marshal header:
+
+    0               1               2               3
+    0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |         Marshal Version       |            Length             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |             Flags             |       p       |      p'       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Data... (differs for sparse/dense case)
+   +-+-+-+-+-+-+-+-+-+-+-+-+-
+
+*/
+
+const (
+	marshalVersion    = 1
+	marshalHeaderSize = 2 + 2 + 2 + 1 + 1
+
+	marshalFlagSparse = 1
+)
+
+// Marshal serializes h into a byte slice that can be deserialized via
+// UnmarshalPlus. Marshal is optimized to produce compact serializations
+// when possible.
+func (h *HyperLogLogPlus) Marshal() []byte {
+	bufSize := marshalHeaderSize
+
+	var (
+		regSize uint8
+		flags   uint16
+	)
+
+	if h.sparse {
+		h.mergeSparse()
+		bufSize += 4 + 4 + len(h.sparseList.b)
+		flags |= marshalFlagSparse
+	} else {
+		// one byte to store regSize
+		bufSize++
+
+		var maxReg uint8
+		for _, r := range h.reg {
+			if r > maxReg {
+				maxReg = r
+				if maxReg >= 32 {
+					break
+				}
+			}
+		}
+
+		regSize = 6
+
+		// use 5 or 4 bits per register if possible
+		if maxReg < 16 {
+			regSize = 4
+		} else if maxReg < 32 {
+			regSize = 5
+		}
+
+		bufSize += int(regSize) * len(h.reg) / 8
+		if (int(regSize)*len(h.reg))%8 > 0 {
+			bufSize++
+		}
+	}
+
+	buf := make([]byte, bufSize)
+
+	offset := 0
+
+	binary.BigEndian.PutUint16(buf[offset:], marshalVersion)
+	offset += 2
+
+	binary.BigEndian.PutUint16(buf[offset:], uint16(len(buf)))
+	offset += 2
+
+	binary.BigEndian.PutUint16(buf[offset:], flags)
+	offset += 2
+
+	buf[offset] = h.p
+	offset += 1
+
+	// add pPrime in case it becomes configurable
+	buf[offset] = pPrime
+	offset += 1
+
+	if h.sparse {
+		binary.BigEndian.PutUint32(buf[offset:], h.sparseList.Count)
+		offset += 4
+
+		binary.BigEndian.PutUint32(buf[offset:], h.sparseList.last)
+		offset += 4
+
+		copy(buf[offset:], h.sparseList.b)
+	} else {
+
+		buf[offset] = regSize
+		offset++
+
+		var (
+			currentByte byte
+
+			// how many bits have we used of current compressed byte
+			bitsUsed uint8
+		)
+		for _, reg := range h.reg {
+			if bitsUsed == 8 {
+				buf[offset] = currentByte
+				offset++
+				currentByte, bitsUsed = 0, 0
+			}
+
+			if bitsUsed <= (8 - regSize) {
+				// can fit register in this byte's remaining bits
+				currentByte |= reg << ((8 - regSize) - bitsUsed)
+				bitsUsed += regSize
+			} else {
+				// can't fit entire register, so complete the current byte with the
+				// first bits of our register, then put remaining register bits in
+				// currentByte
+				buf[offset] = currentByte | reg>>(bitsUsed-(8-regSize))
+				offset++
+				currentByte = reg << (8 - (bitsUsed - (8 - regSize)))
+				bitsUsed = regSize - (8 - bitsUsed)
+			}
+		}
+
+		if bitsUsed > 0 {
+			buf[offset] = currentByte
+			offset++
+		}
+	}
+
+	return buf
+}
+
+// UnmarshalPlus deserializes the result of Marshal back into a HyperLogLogPlus
+// object.
+func UnmarshalPlus(data []byte) (*HyperLogLogPlus, error) {
+	if len(data) < marshalHeaderSize {
+		return nil, fmt.Errorf("data too short (%d bytes)", len(data))
+	}
+
+	offset := 0
+
+	version := binary.BigEndian.Uint16(data[offset:])
+	offset += 2
+
+	if version != marshalVersion {
+		return nil, fmt.Errorf("unknown version: %d", version)
+	}
+
+	length := binary.BigEndian.Uint16(data[offset:])
+	offset += 2
+
+	if int(length) != len(data) {
+		return nil, fmt.Errorf("length mismatch: header says %d, was %d", length, len(data))
+	}
+
+	flags := binary.BigEndian.Uint16(data[offset:])
+	offset += 2
+
+	p := data[offset]
+	offset++
+
+	pp := data[offset]
+	offset++
+
+	// for now check that pPrime is the default value
+	if pp != pPrime {
+		return nil, fmt.Errorf("unexpected p' value: %d", pp)
+	}
+
+	h, err := NewPlus(p)
+	if err != nil {
+		return nil, err
+	}
+
+	if flags&marshalFlagSparse > 0 {
+		h.sparseList.Count = binary.BigEndian.Uint32(data[offset:])
+		offset += 4
+
+		h.sparseList.last = binary.BigEndian.Uint32(data[offset:])
+		offset += 4
+
+		h.sparseList.b = h.sparseList.b[:len(data)-offset]
+		copy(h.sparseList.b, data[offset:])
+	} else {
+		regSize := data[offset]
+		offset++
+
+		h.sparse = false
+		h.tmpSet = nil
+		h.sparseList = nil
+
+		h.reg = make([]uint8, h.m)
+
+		var (
+			regIdx int
+
+			// current register we are decompressing
+			byteSoFar uint8
+
+			// number of bits we need to make next complete register
+			numBitsLeft uint8 = regSize
+		)
+
+		for _, b := range data[offset:] {
+			h.reg[regIdx] = byteSoFar | (b >> (8 - numBitsLeft))
+			regIdx++
+
+			byteSoFar = (b << numBitsLeft) >> (8 - regSize)
+
+			if numBitsLeft <= (8 - regSize) {
+				// we know byteSoFar holds the complete register
+				h.reg[regIdx] = byteSoFar
+				regIdx++
+				byteSoFar = (b << (numBitsLeft + regSize)) >> (8 - regSize)
+				numBitsLeft = regSize - (8 - (numBitsLeft + regSize))
+			} else {
+				numBitsLeft = regSize - (8 - numBitsLeft)
+			}
+		}
+	}
+
+	return h, nil
+}

--- a/marshalplus_test.go
+++ b/marshalplus_test.go
@@ -25,6 +25,14 @@ func realHash64(n int64) fakeHash64 {
 	return fakeHash64(binary.BigEndian.Uint64(checksum[:]))
 }
 
+func mustMarshal(h *HyperLogLogPlus) []byte {
+	marshaled, err := h.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return marshaled
+}
+
 func hllpEqual(h1, h2 HyperLogLogPlus) bool {
 	h1Sparse := h1.sparseList
 	h1.sparseList = nil
@@ -48,7 +56,7 @@ func hllpEqual(h1, h2 HyperLogLogPlus) bool {
 }
 
 func marshalUnmarshal(h *HyperLogLogPlus) error {
-	unmarshaled, err := UnmarshalPlus(h.Marshal())
+	unmarshaled, err := UnmarshalPlus(mustMarshal(h))
 	if err != nil {
 		panic(err)
 	}
@@ -109,7 +117,7 @@ func TestMarshalDense(t *testing.T) {
 		t.Error("expecting dense")
 	}
 
-	if len(h.Marshal()) >= 5*len(h.reg)/8 {
+	if len(mustMarshal(h)) >= 5*len(h.reg)/8 {
 		t.Error("Expected to compress below 5 bits to the byte")
 	}
 
@@ -135,7 +143,7 @@ func TestMarshalDense(t *testing.T) {
 		break
 	}
 
-	if len(h.Marshal()) >= 6*len(h.reg)/8 {
+	if len(mustMarshal(h)) >= 6*len(h.reg)/8 {
 		t.Error("Expected to compress below 6 bits to the byte")
 	}
 
@@ -177,7 +185,7 @@ func TestUnmarshalErrors(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		h.Add(realHash64(rand.Int63()))
 	}
-	uh, err = UnmarshalPlus(h.Marshal()[0:100])
+	uh, err = UnmarshalPlus(mustMarshal(h)[0:100])
 	if uh != nil || err == nil {
 		t.Error("Expected nil hll and some error")
 	}

--- a/marshalplus_test.go
+++ b/marshalplus_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2015, RetailNext, Inc.
+// This material contains trade secrets and confidential information of
+// RetailNext, Inc.  Any use, reproduction, disclosure or dissemination
+// is strictly prohibited without the explicit written permission
+// of RetailNext, Inc.
+// All rights reserved.
+package hyperloglog
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// use a real hash so we actually fill up all the registers (rand.Int63()
+// will leave the second half of your registers empty since it will never
+// have the MSB set)
+func realHash64(n int64) fakeHash64 {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(n))
+	checksum := sha1.Sum(buf)
+	return fakeHash64(binary.BigEndian.Uint64(checksum[:]))
+}
+
+func hllpEqual(h1, h2 HyperLogLogPlus) bool {
+	h1Sparse := h1.sparseList
+	h1.sparseList = nil
+
+	h2Sparse := h2.sparseList
+	h2.sparseList = nil
+
+	if !reflect.DeepEqual(h1, h2) {
+		return false
+	}
+
+	if h1Sparse == nil && h2Sparse == nil {
+		return true
+	}
+
+	if h1Sparse == nil || h2Sparse == nil {
+		return false
+	}
+
+	return reflect.DeepEqual(*h1Sparse, *h2Sparse)
+}
+
+func marshalUnmarshal(h *HyperLogLogPlus) error {
+	unmarshaled, err := UnmarshalPlus(h.Marshal())
+	if err != nil {
+		panic(err)
+	}
+
+	if !hllpEqual(*h, *unmarshaled) {
+		return fmt.Errorf("Got %+v, expected %+v", unmarshaled, h)
+	} else {
+		return nil
+	}
+}
+
+// Some white-box testing that we have the same hll after marshal/unmarshal
+
+func TestMarshalSparse(t *testing.T) {
+	h, _ := NewPlus(14)
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+
+	h.Add(realHash64(1))
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+
+	for i := 0; i < 100; i++ {
+		h.Add(realHash64(rand.Int63()))
+	}
+
+	if !h.sparse {
+		t.Error("expecting sparse!")
+	}
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+}
+
+func leadingZeroes(h *HyperLogLogPlus, x uint64) uint8 {
+	w := x<<h.p | 1<<(h.p-1)
+	return clz64(w) + 1
+}
+
+func TestMarshalDense(t *testing.T) {
+	h, _ := NewPlus(14)
+
+	// first make sure we don't have anything more than 15 leading zeroes so we
+	// can test 4 bits per register
+	for i := 0; i < 10000; i++ {
+		x := realHash64(rand.Int63())
+		if leadingZeroes(h, x.Sum64()) < 16 {
+			h.Add(x)
+		}
+	}
+
+	if h.sparse {
+		t.Error("expecting dense")
+	}
+
+	if len(h.Marshal()) >= 5*len(h.reg)/8 {
+		t.Error("Expected to compress below 5 bits to the byte")
+	}
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+
+	// now add up to 31 leading zeroes so we can test 5 bit compression
+	for i := 0; i < 100000; i++ {
+		x := realHash64(rand.Int63())
+		if leadingZeroes(h, x.Sum64()) < 32 {
+			h.Add(x)
+		}
+	}
+
+	// make sure we have at least one thing > 15 zeroes
+	for {
+		x := realHash64(rand.Int63())
+		if leadingZeroes(h, x.Sum64()) < 16 {
+			continue
+		}
+		h.Add(x)
+		break
+	}
+
+	if len(h.Marshal()) >= 6*len(h.reg)/8 {
+		t.Error("Expected to compress below 6 bits to the byte")
+	}
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+
+	// force hash value with lots of leading zeroes, so can't compress registers
+	// below 6 bits
+	h.Add(fakeHash64(0))
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+
+	// fill up registers
+	for i := 0; i < 1000000; i++ {
+		h.Add(realHash64(rand.Int63()))
+	}
+
+	if err := marshalUnmarshal(h); err != nil {
+		t.Error(err)
+	}
+}
+
+// make sure we validate bytes before trying to unmarshal
+func TestUnmarshalErrors(t *testing.T) {
+	uh, err := UnmarshalPlus(nil)
+	if uh != nil || err == nil {
+		t.Error("Expected nil hll and some error")
+	}
+
+	uh, err = UnmarshalPlus([]byte{})
+	if uh != nil || err == nil {
+		t.Error("Expected nil hll and some error")
+	}
+
+	h, _ := NewPlus(14)
+	for i := 0; i < 10000; i++ {
+		h.Add(realHash64(rand.Int63()))
+	}
+	uh, err = UnmarshalPlus(h.Marshal()[0:100])
+	if uh != nil || err == nil {
+		t.Error("Expected nil hll and some error")
+	}
+}


### PR DESCRIPTION
This is to make it easy to persist your HLL++s to disk/database. I tried to optimize for space, not CPU. The sparse list is snappy compressed, and the dense list uses fewer bits to store each register if possible.

There was a little bit of whitespace change in compressed.go from gofmt.

I would appreciate any feedback have.