### PR TITLE
Updated benchmarks to use the fnv-a variant.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func hash32(s string) hash.Hash32 {
-	h := fnv.New32()
+	h := fnv.New32a()
 	h.Write([]byte(s))
 	return h
 }
 
 func hash64(s string) hash.Hash64 {
-	h := fnv.New64()
+	h := fnv.New64a()
 	h.Write([]byte(s))
 	return h
 }


### PR DESCRIPTION
This improves the avalanche characteristic and avoids the issue found in:
    https://github.com/clarkduvall/hyperloglog/issues/10

I ran the benchmark.  Code compiles fine; outputs look reasonable.