### PR TITLE
Streaming serialization with gob.

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -12,7 +12,9 @@
 package hyperloglog
 
 import (
+	"encoding/gob"
 	"errors"
+	"io"
 	"math"
 )
 
@@ -80,4 +82,38 @@ func (h *HyperLogLog) Count() uint64 {
 		return uint64(est)
 	}
 	return uint64(-two32 * math.Log(1-est/two32))
+}
+
+// Marshal writes HyperLogLog to a writer.
+func (h *HyperLogLog) Marshal(w io.Writer) error {
+	enc := gob.NewEncoder(w)
+
+	if err := enc.Encode(h.reg); err != nil {
+		return err
+	}
+	if err := enc.Encode(h.m); err != nil {
+		return err
+	}
+	if err := enc.Encode(h.p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Unmarshal reads HyperLogLog from a reader.
+func Unmarshal(r io.Reader) (*HyperLogLog, error) {
+	dec := gob.NewDecoder(r)
+	var h HyperLogLog
+
+	if err := dec.Decode(&h.reg); err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(&h.m); err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(&h.p); err != nil {
+		return nil, err
+	}
+	return &h, nil
 }

--- a/hyperloglog_test.go
+++ b/hyperloglog_test.go
@@ -1,6 +1,10 @@
 package hyperloglog
 
-import "testing"
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
 
 type fakeHash32 uint32
 
@@ -170,5 +174,30 @@ func TestHLLError(t *testing.T) {
 	_, err = New(17)
 	if err == nil {
 		t.Error("precision 17 should return error")
+	}
+}
+
+func TestHLLPMarshal(t *testing.T) {
+	h1, _ := New(8)
+	h1.Add(fakeHash32(0x00010fff))
+	h1.Add(fakeHash32(0x00020fff))
+	h1.Add(fakeHash32(0x00030fff))
+	h1.Add(fakeHash32(0x00040fff))
+	h1.Add(fakeHash32(0x00050fff))
+
+	var buf bytes.Buffer
+	err := h1.Marshal(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	r := bytes.NewReader(buf.Bytes())
+	h2, err := Unmarshal(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(h1, h2) {
+		t.Error("unmarshaled result should match original")
 	}
 }


### PR DESCRIPTION
This is an alternative PR which build around io writers/readers rather than a []byte.

It uses gob, but things are complicated a bit because:
1) hll and hllp structs don't export their members
2) there possible nil pointers at times

I added the complication handling in marshal/unmarshal rather than make a more invasive package-wide change to play nice with gob.

One other benefit over the other PR... this maintains the sparse state for hllp when applicable.