### PR TITLE
added GobEncoder/GobDecoder interfaces to HyperLogLog and HyperLogLog+

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -12,6 +12,8 @@
 package hyperloglog
 
 import (
+	"bytes"
+	"encoding/gob"
 	"errors"
 	"math"
 )
@@ -80,4 +82,35 @@ func (h *HyperLogLog) Count() uint64 {
 		return uint64(est)
 	}
 	return uint64(-two32 * math.Log(1-est/two32))
+}
+
+// Encode HyperLogLog into a gob
+func (h *HyperLogLog) GobEncode() ([]byte, error) {
+	buf := bytes.Buffer{}
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(h.reg); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(h.m); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(h.p); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Decode gob into a HyperLogLog structure
+func (h *HyperLogLog) GobDecode(b []byte) error {
+	dec := gob.NewDecoder(bytes.NewBuffer(b))
+	if err := dec.Decode(&h.reg); err != nil {
+		return err
+	}
+	if err := dec.Decode(&h.m); err != nil {
+		return err
+	}
+	if err := dec.Decode(&h.p); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
I see that other efforts to add serialization/deserialization to HLL are not merged yet, so let me offer another one, because I find it critical to be able to save HLL counter and restore it if app is restarted.

Basically, I've added gob-compatible interfaces, so HLL and HLLP inside custom structs can be saved/restored seamlessly.