### PR TITLE
Make sure toNormal is eventually done even if Count is called often

### DIFF
--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -235,7 +235,11 @@ func (h *HyperLogLogPlus) estimateBias(est float64) float64 {
 func (h *HyperLogLogPlus) Count() uint64 {
 	if h.sparse {
 		h.mergeSparse()
-		return uint64(linearCounting(mPrime, mPrime-uint32(h.sparseList.Count)))
+		if uint32(h.sparseList.Len()) > h.m {
+			h.toNormal()
+		} else {
+			return uint64(linearCounting(mPrime, mPrime-uint32(h.sparseList.Count)))
+		}
 	}
 
 	est := calculateEstimate(h.reg)


### PR DESCRIPTION
Our app, for various reasons, always calls Count after adding a bunch of items. This has the unfortunate side effect that toNormal never gets called - because Count calls mergeSparse and this resets the size of tmpSet to zero. Thus the size of tmpSet is never big enough for maybeToNormal to trigger toNormal.

The end result is we have a sparseList of millions of items, and Count is very slow (hundreds of milliseconds).

This patch fixes this by checking if the threshold is reached during Count.