### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -100,7 +100,7 @@ func (h *HyperLogLog) GobEncode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Decode gob into a HyperLogLog structure
+// GobDecode decodes gob into a HyperLogLog structure
 func (h *HyperLogLog) GobDecode(b []byte) error {
 	dec := gob.NewDecoder(bytes.NewBuffer(b))
 	if err := dec.Decode(&h.reg); err != nil {

--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -293,7 +293,7 @@ func (h *HyperLogLogPlus) GobEncode() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Decode gob into a HyperLogLogPlus structure
+// GobDecode decodes gob into a HyperLogLogPlus structure
 func (h *HyperLogLogPlus) GobDecode(b []byte) error {
 	dec := gob.NewDecoder(bytes.NewBuffer(b))
 	if err := dec.Decode(&h.reg); err != nil {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._