### PR TITLE
Added overload for HLL++ to Add uint64 in place of Hash

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -23,7 +23,7 @@ func hash64(s string) hash.Hash64 {
 
 func randStr(n int) string {
 	i := rand.Uint32()
-	return fmt.Sprintf("a%s %s", i, n)
+	return fmt.Sprintf("a%d %d", i, n)
 }
 
 func benchmark(precision uint8, n int) {

--- a/hyperloglogplus.go
+++ b/hyperloglogplus.go
@@ -145,13 +145,17 @@ func (h *HyperLogLogPlus) toNormal() {
 
 // Add adds a new item to HyperLogLogPlus h.
 func (h *HyperLogLogPlus) Add(item Hash64) {
-	x := item.Sum64()
+	h.AddUInt64(item.Sum64())
+}
+
+// Add adds a new item to HyperLogLogPlus h.
+func (h *HyperLogLogPlus) AddUInt64(item uint64) {
 	if h.sparse {
-		h.tmpSet.Add(h.encodeHash(x))
+		h.tmpSet.Add(h.encodeHash(item))
 		h.maybeMerge()
 	} else {
-		i := eb64(x, 64, 64-h.p) // {x63,...,x64-p}
-		w := x<<h.p | 1<<(h.p-1) // {x63-p,...,x0}
+		i := eb64(item, 64, 64-h.p) // {x63,...,x64-p}
+		w := item<<h.p | 1<<(h.p-1) // {x63-p,...,x0}
 
 		zeroBits := clz64(w) + 1
 		if zeroBits > h.reg[i] {

--- a/hyperloglogplus_test.go
+++ b/hyperloglogplus_test.go
@@ -53,7 +53,7 @@ func TestHLLPPAddNoSparse(t *testing.T) {
 		t.Error(n)
 	}
 
-	h.Add(fakeHash64(0xff03080000000000))
+	h.AddUInt64(fakeHash64(0xff03080000000000).Sum64())
 	n = h.reg[0xff03]
 	if n != 5 {
 		t.Error(n)


### PR DESCRIPTION
It helps when using fash hash libraries like
https://github.com/segmentio/fasthash/ as using hash does two
allocations for every operation.